### PR TITLE
Logo fix in layout

### DIFF
--- a/src/MezzioInstaller/Resources/templates/laminas-view/home-page.phtml
+++ b/src/MezzioInstaller/Resources/templates/laminas-view/home-page.phtml
@@ -1,7 +1,7 @@
 <?php $this->headTitle('Home'); ?>
 
 <div class="jumbotron">
-    <h1>Welcome to <span class="api-tools-green">mezzio</span></h1>
+    <h1>Welcome to <span class="mezzio-green">mezzio</span></h1>
     <p>
         Congratulations! You have successfully installed the
         <a href="https://github.com/mezzio/mezzio-skeleton" target="_blank">mezzio skeleton application</a>.

--- a/src/MezzioInstaller/Resources/templates/laminas-view/layout.phtml
+++ b/src/MezzioInstaller/Resources/templates/laminas-view/layout.phtml
@@ -20,7 +20,9 @@ $this->inlineScript()
         body { padding-top: 70px; }
         .app { min-height: 100vh; }
         .app-footer { padding-bottom: 1em; }
-        .api-tools-green, h2 a { color: #68b604; }
+        .mezzio-green, h2 a, h2 a:hover { color: #009655; }
+        .navbar-brand { padding: 0; }
+        .navbar-brand img { margin: -.5rem 0; filter: brightness(0) invert(1); }
     </style>
 </head>
 <body class="app">
@@ -33,7 +35,7 @@ $this->inlineScript()
                     </button>
                     <!-- Brand -->
                     <a class="navbar-brand" href="<?=$this->url('home')?>">
-                        <img src="https://getlaminas.org/images/logo/laminas-foundation-white.svg" alt="Laminas Mezzio" height="28" />
+                        <img src="https://docs.laminas.dev/img/laminas-mezzio-rgb.svg" alt="Laminas Mezzio" height="56" />
                     </a>
                 </div>
                 <!-- Links -->

--- a/src/MezzioInstaller/Resources/templates/laminas-view/layout.phtml
+++ b/src/MezzioInstaller/Resources/templates/laminas-view/layout.phtml
@@ -33,7 +33,7 @@ $this->inlineScript()
                     </button>
                     <!-- Brand -->
                     <a class="navbar-brand" href="<?=$this->url('home')?>">
-                        <img src="https://getlaminas.org/images/logos/api-tools-logo-mark.png" alt="Laminas Mezzio" height="28" />
+                        <img src="https://getlaminas.org/images/logo/laminas-foundation-white.svg" alt="Laminas Mezzio" height="28" />
                     </a>
                 </div>
                 <!-- Links -->

--- a/src/MezzioInstaller/Resources/templates/plates/home-page.phtml
+++ b/src/MezzioInstaller/Resources/templates/plates/home-page.phtml
@@ -1,7 +1,7 @@
 <?php $this->layout('layout::default', ['title' => 'Home']) ?>
 
 <div class="jumbotron">
-    <h1>Welcome to <span class="api-tools-green">mezzio</span></h1>
+    <h1>Welcome to <span class="mezzio-green">mezzio</span></h1>
     <p>
         Congratulations! You have successfully installed the
         <a href="https://github.com/mezzio/mezzio-skeleton" target="_blank">mezzio skeleton application</a>.

--- a/src/MezzioInstaller/Resources/templates/plates/layout.phtml
+++ b/src/MezzioInstaller/Resources/templates/plates/layout.phtml
@@ -12,7 +12,9 @@
         body { padding-top: 70px; }
         .app { min-height: 100vh; }
         .app-footer { padding-bottom: 1em; }
-        .api-tools-green, h2 a { color: #68b604; }
+        .mezzio-green, h2 a, h2 a:hover { color: #009655; }
+        .navbar-brand { padding: 0; }
+        .navbar-brand img { margin: -.5rem 0; filter: brightness(0) invert(1); }
     </style>
     <?=$this->section('stylesheets')?>
 </head>
@@ -26,7 +28,7 @@
                     </button>
                     <!-- Brand -->
                     <a class="navbar-brand" href="/">
-                        <img src="https://getlaminas.org/images/logo/laminas-foundation-white.svg" alt="Laminas Mezzio" height="28" />
+                        <img src="https://docs.laminas.dev/img/laminas-mezzio-rgb.svg" alt="Laminas Mezzio" height="56" />
                     </a>
                 </div>
                 <!-- Links -->

--- a/src/MezzioInstaller/Resources/templates/plates/layout.phtml
+++ b/src/MezzioInstaller/Resources/templates/plates/layout.phtml
@@ -26,7 +26,7 @@
                     </button>
                     <!-- Brand -->
                     <a class="navbar-brand" href="/">
-                        <img src="https://getlaminas.org/images/logos/api-tools-logo-mark.png" alt="Laminas Mezzio" height="28" />
+                        <img src="https://getlaminas.org/images/logo/laminas-foundation-white.svg" alt="Laminas Mezzio" height="28" />
                     </a>
                 </div>
                 <!-- Links -->

--- a/src/MezzioInstaller/Resources/templates/twig/home-page.html.twig
+++ b/src/MezzioInstaller/Resources/templates/twig/home-page.html.twig
@@ -4,7 +4,7 @@
 
 {% block content %}
     <div class="jumbotron">
-        <h1>Welcome to <span class="api-tools-green">mezzio</span></h1>
+        <h1>Welcome to <span class="mezzio-green">mezzio</span></h1>
         <p>
             Congratulations! You have successfully installed the
             <a href="https://github.com/mezzio/mezzio-skeleton" target="_blank">mezzio skeleton application</a>.

--- a/src/MezzioInstaller/Resources/templates/twig/layout.html.twig
+++ b/src/MezzioInstaller/Resources/templates/twig/layout.html.twig
@@ -26,7 +26,7 @@
                     </button>
                     <!-- Brand -->
                     <a class="navbar-brand" href="{{ path('home') }}">
-                        <img src="https://getlaminas.org/images/logos/api-tools-logo-mark.png" alt="Laminas Mezzio" height="28" />
+                        <img src="https://getlaminas.org/images/logo/laminas-foundation-white.svg" alt="Laminas Mezzio" height="28" />
                     </a>
                 </div>
                 <!-- Links -->

--- a/src/MezzioInstaller/Resources/templates/twig/layout.html.twig
+++ b/src/MezzioInstaller/Resources/templates/twig/layout.html.twig
@@ -12,7 +12,9 @@
         body { padding-top: 70px; }
         .app { min-height: 100vh; }
         .app-footer { padding-bottom: 1em; }
-        .api-tools-green, h2 a { color: #68b604; }
+        .mezzio-green, h2 a, h2 a:hover { color: #009655; }
+        .navbar-brand { padding: 0; }
+        .navbar-brand img { margin: -.5rem 0; filter: brightness(0) invert(1); }
     </style>
     {% block stylesheets %}{% endblock %}
 </head>
@@ -26,7 +28,7 @@
                     </button>
                     <!-- Brand -->
                     <a class="navbar-brand" href="{{ path('home') }}">
-                        <img src="https://getlaminas.org/images/logo/laminas-foundation-white.svg" alt="Laminas Mezzio" height="28" />
+                        <img src="https://docs.laminas.dev/img/laminas-mezzio-rgb.svg" alt="Laminas Mezzio" height="56" />
                     </a>
                 </div>
                 <!-- Links -->


### PR DESCRIPTION
Previously, the logo is pointed to `https://getlaminas.org/images/logos/api-tools-logo-mark.png` which not exists, it seems it was replaced when migrating. Updated to `https://getlaminas.org/images/logo/laminas-foundation-white.svg` to get correct logo location.

![Screen Shot 2020-01-27 at 2 25 09 PM](https://user-images.githubusercontent.com/459648/73156594-d9591e80-4110-11ea-8b4d-ee191e75cefe.png)
