### PR TITLE
fix pimple and auryn containerName cases

### DIFF
--- a/src/App/src/Handler/HomePageHandler.php
+++ b/src/App/src/Handler/HomePageHandler.php
@@ -50,7 +50,7 @@ class HomePageHandler implements RequestHandlerInterface
         switch ($this->containerName) {
             case 'Aura\Di\Container':
                 $data['containerName'] = 'Aura.Di';
-                $data['containerDocs'] = 'http://auraphp.com/packages/2.x/Di.html';
+                $data['containerDocs'] = 'http://auraphp.com/packages/3.x/Di/';
                 break;
             case 'Pimple\Psr11\Container':
                 $data['containerName'] = 'Pimple';

--- a/src/App/src/Handler/HomePageHandler.php
+++ b/src/App/src/Handler/HomePageHandler.php
@@ -52,7 +52,7 @@ class HomePageHandler implements RequestHandlerInterface
                 $data['containerName'] = 'Aura.Di';
                 $data['containerDocs'] = 'http://auraphp.com/packages/2.x/Di.html';
                 break;
-            case 'Pimple\Container':
+            case 'Pimple\Psr11\Container':
                 $data['containerName'] = 'Pimple';
                 $data['containerDocs'] = 'https://pimple.symfony.com/';
                 break;

--- a/src/App/src/Handler/HomePageHandler.php
+++ b/src/App/src/Handler/HomePageHandler.php
@@ -60,7 +60,7 @@ class HomePageHandler implements RequestHandlerInterface
                 $data['containerName'] = 'Laminas Servicemanager';
                 $data['containerDocs'] = 'https://docs.laminas.dev/laminas-servicemanager/';
                 break;
-            case 'Auryn\Injector':
+            case 'Northwoods\Container\InjectorContainer':
                 $data['containerName'] = 'Auryn';
                 $data['containerDocs'] = 'https://github.com/rdlowrey/Auryn';
                 break;

--- a/test/MezzioInstallerTest/HomePageResponseTest.php
+++ b/test/MezzioInstallerTest/HomePageResponseTest.php
@@ -69,7 +69,7 @@ class HomePageResponseTest extends OptionalPackagesTestCase
     private $expectedContainerAttributes = [
         AuraDiContainer::class => [
             'containerName' => 'Aura.Di',
-            'containerDocs' => 'http://auraphp.com/packages/2.x/Di.html',
+            'containerDocs' => 'http://auraphp.com/packages/3.x/Di/',
         ],
         PimpleContainer::class => [
             'containerName' => 'Pimple',

--- a/test/MezzioInstallerTest/HomePageResponseTest.php
+++ b/test/MezzioInstallerTest/HomePageResponseTest.php
@@ -1,0 +1,222 @@
+<?php
+
+/**
+ * @see       https://github.com/mezzio/mezzio-skeleton for the canonical source repository
+ * @copyright https://github.com/mezzio/mezzio-skeleton/blob/master/COPYRIGHT.md
+ * @license   https://github.com/mezzio/mezzio-skeleton/blob/master/LICENSE.md New BSD License
+ */
+
+declare(strict_types=1);
+
+namespace MezzioInstallerTest;
+
+use Generator;
+use Mezzio\Router\FastRouteRouter\ConfigProvider as FastRouteRouterConfigProvider;
+use MezzioInstaller\OptionalPackages;
+// Containers imports ordered by install-options sorting
+use Aura\Di\Container as AuraDiContainer;
+use Pimple\Psr11\Container as PimpleContainer;
+use Laminas\ServiceManager\ServiceManager as LaminasServiceManagerContainer;
+use Northwoods\Container\InjectorContainer as AurynContainer;
+use Symfony\Component\DependencyInjection\ContainerBuilder as SfContainerBuilder;
+use DI\Container as PhpDIContainer;
+// Renderers imports ordered by install-options sorting
+use Mezzio\Plates\ConfigProvider as PlatesRendererConfigProvider;
+use Mezzio\Plates\PlatesRenderer;
+use Mezzio\Twig\ConfigProvider as TwigRendererConfigProvider;
+use Mezzio\Twig\TwigRenderer;
+use Mezzio\LaminasView\ConfigProvider as LaminasViewRendererConfigProvider;
+use Mezzio\LaminasView\LaminasViewRenderer;
+
+class HomePageResponseTest extends OptionalPackagesTestCase
+{
+    use ProjectSandboxTrait;
+
+    /**
+     * @var OptionalPackages
+     */
+    private $installer;
+
+    private $rendererConfigProviders = [
+        PlatesRenderer::class   => PlatesRendererConfigProvider::class,
+        TwigRenderer::class     => TwigRendererConfigProvider::class,
+        LaminasViewRenderer::class => LaminasViewRendererConfigProvider::class,
+    ];
+
+    // $intallType, $intallType
+    private $intallTypes = [
+        OptionalPackages::INSTALL_FLAT    => OptionalPackages::INSTALL_FLAT,
+        OptionalPackages::INSTALL_MODULAR => OptionalPackages::INSTALL_MODULAR,
+    ];
+
+    // $rendererOption, $rendererClass
+    private $rendererTypes = [
+        'plates'       => [1, PlatesRenderer::class],
+        'twig'         => [2, TwigRenderer::class],
+        'laminas-view' => [3, LaminasViewRenderer::class],
+    ];
+
+    // $containerOption, $containerClass
+    private $containerTypes = [
+        'aura-di' => [1, AuraDiContainer::class],
+        'pimple'  => [2, PimpleContainer::class],
+        'laminas-servicemanager' => [3, LaminasServiceManagerContainer::class],
+        'auryn'   => [4, AurynContainer::class],
+        'sf-di'   => [5, SfContainerBuilder::class],
+        'php-di'  => [6, PhpDIContainer::class],
+    ];
+
+    private $expectedContainerAttributes = [
+        AuraDiContainer::class => [
+            'containerName' => 'Aura.Di',
+            'containerDocs' => 'http://auraphp.com/packages/2.x/Di.html',
+        ],
+        PimpleContainer::class => [
+            'containerName' => 'Pimple',
+            'containerDocs' => 'https://pimple.symfony.com/',
+        ],
+        LaminasServiceManagerContainer::class => [
+            'containerName' => 'Laminas Servicemanager',
+            'containerDocs' => 'https://docs.laminas.dev/laminas-servicemanager/',
+        ],
+        AurynContainer::class => [
+            'containerName' => 'Auryn',
+            'containerDocs' => 'https://github.com/rdlowrey/Auryn',
+        ],
+        SfContainerBuilder::class => [
+            'containerName' => 'Symfony DI Container',
+            'containerDocs' => 'https://symfony.com/doc/current/service_container.html',
+        ],
+        PhpDIContainer::class => [
+            'containerName' => 'PHP-DI',
+            'containerDocs' => 'http://php-di.org',
+        ],
+    ];
+
+    protected function setUp() : void
+    {
+        parent::setUp();
+        $this->projectRoot = $this->copyProjectFilesToTempFilesystem();
+        $this->installer   = $this->createOptionalPackages($this->projectRoot);
+    }
+
+    protected function tearDown() : void
+    {
+        parent::tearDown();
+        chdir($this->packageRoot);
+        $this->recursiveDelete($this->projectRoot);
+        $this->tearDownAlternateAutoloader();
+    }
+
+    /**
+     * @runInSeparateProcess
+     *
+     * @dataProvider installCasesProvider
+     */
+    public function testHomePageResponseContainsCorrectContainerInfo(
+        string $installType,
+        int $containerOption,
+        string $containerClass,
+        int $rendererOption,
+        string $rendererClass,
+        string $containerName,
+        string $containerDocs
+    ) {
+        $this->prepareSandboxForInstallType($installType, $this->installer);
+
+        // Install container
+        $config = $this->getInstallerConfig($this->installer);
+        $containerResult = $this->installer->processAnswer(
+            $config['questions']['container'],
+            $containerOption
+        );
+        $this->assertTrue($containerResult);
+
+        // Install router
+        $routerResult = $this->installer->processAnswer(
+            $config['questions']['router'],
+            $routerOption = 2 // FastRoute, use assignment for clarity
+        );
+        $this->assertTrue($routerResult);
+        $this->injectRouterConfigProvider();
+
+        // Install template engine
+        $templateEngineResult = $this->installer->processAnswer(
+            $config['questions']['template-engine'],
+            $rendererOption
+        );
+        $this->assertTrue($templateEngineResult);
+        $this->injectRendererConfigProvider($rendererClass);
+
+        // Test home page response
+        $response = $this->getAppResponse('/', true);
+        $this->assertEquals(200, $response->getStatusCode());
+
+        // Test response content
+        $html = (string) $response->getBody()->getContents();
+
+        $this->assertNotFalse(strpos($html, "Get started with {$containerName}"));
+        $this->assertNotFalse(strpos($html, "href=\"{$containerDocs}\""));
+    }
+
+    public function installCasesProvider() : Generator
+    {
+        // Execute a test case for each container, renderer and non minimal install type
+        foreach ($this->containerTypes as $containerID => $containerType) {
+            $containerOption = $containerType[0];
+            $containerClass  = $containerType[1];
+
+            $containerName = $this->expectedContainerAttributes[$containerClass]['containerName'];
+            $containerDocs = $this->expectedContainerAttributes[$containerClass]['containerDocs'];
+
+            foreach ($this->rendererTypes as $rendererID => $rendererType) {
+                $rendererOption = $rendererType[0];
+                $rendererClass  = $rendererType[1];
+
+                // skip laminas-view / non laminas-servicemanager combinations
+                if (3 === $rendererOption && 3 !== $containerOption) {
+                    continue;
+                }
+
+                foreach ($this->intallTypes as $intallType) {
+                    $name = implode('--', [$containerID, $rendererID, $intallType]);
+                    $args = [
+                        $intallType,
+                        $containerOption,
+                        $containerClass,
+                        $rendererOption,
+                        $rendererClass,
+                        $containerName,
+                        $containerDocs,
+                    ];
+
+                    yield $name => $args;
+                }
+            }
+        }
+    }
+
+    public function injectRouterConfigProvider()
+    {
+        $configFile = $this->projectRoot . '/config/config.php';
+        $contents = file_get_contents($configFile);
+        $contents = preg_replace(
+            '/(new ConfigAggregator\(\[)/s',
+            '$1' . "\n    " . FastRouteRouterConfigProvider::class . "::class,\n",
+            $contents
+        );
+        file_put_contents($configFile, $contents);
+    }
+
+    public function injectRendererConfigProvider(string $rendererClass)
+    {
+        $configFile = $this->projectRoot . '/config/config.php';
+        $contents = file_get_contents($configFile);
+        $contents = preg_replace(
+            '/(new ConfigAggregator\(\[)/s',
+            '$1' . "\n    " . $this->rendererConfigProviders[$rendererClass] . "::class,\n",
+            $contents
+        );
+        file_put_contents($configFile, $contents);
+    }
+}


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | yes
| BC Break      | no
| New Feature   | no
| RFC           | no
| QA            | no

### Description

The container used by the home-page handler factory could be a pimple psr11-wrapper `Pimple\Psr11\Container`, not a `Pimple\Container` instance.
