### PR TITLE
Fixes failing unit tests due to change in package structure

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -69,7 +69,7 @@
         "phpspec/prophecy": "^1.10.3",
         "phpstan/phpstan": "^0.9.3",
         "phpstan/phpstan-strict-rules": "^0.9",
-        "phpunit/phpunit": "^7.5.20 || ^8.5.2 || ^9.0.1",
+        "phpunit/phpunit": "^8.5.8 || ^9.3.7",
         "roave/security-advisories": "dev-master",
         "squizlabs/php_codesniffer": "^2.9.2"
     },

--- a/test/MezzioInstallerTest/RemoveInstallerTest.php
+++ b/test/MezzioInstallerTest/RemoveInstallerTest.php
@@ -31,7 +31,6 @@ class RemoveInstallerTest extends OptionalPackagesTestCase
 
         $this->assertTrue(isset($composer['autoload']['psr-4']['MezzioInstaller\\']));
         $this->assertTrue(isset($composer['autoload-dev']['psr-4']['MezzioInstallerTest\\']));
-        $this->assertTrue(isset($composer['extra']['branch-alias']));
         $this->assertFalse(isset($composer['extra']['optional-packages']));
         $this->assertTrue(isset($composer['scripts']['pre-install-cmd']));
         $this->assertTrue(isset($composer['scripts']['pre-update-cmd']));
@@ -46,7 +45,6 @@ class RemoveInstallerTest extends OptionalPackagesTestCase
 
         $this->assertFalse(isset($composer['autoload']['psr-4']['MezzioInstaller\\']));
         $this->assertFalse(isset($composer['autoload-dev']['psr-4']['MezzioInstallerTest\\']));
-        $this->assertFalse(isset($composer['extra']['branch-alias']));
         $this->assertFalse(isset($composer['extra']['optional-packages']));
         $this->assertFalse(isset($composer['scripts']['pre-install-cmd']));
         $this->assertFalse(isset($composer['scripts']['pre-update-cmd']));


### PR DESCRIPTION
Since `branch-aliases` is no longer defined, those assertions were no
longer necessary.

Additionally, updated PHPUnit constraints.