### PR TITLE
Remove unnecessary size check on static files

### DIFF
--- a/public/.htaccess
+++ b/public/.htaccess
@@ -3,7 +3,7 @@ RewriteEngine On
 RewriteRule .* - [E=HTTP_AUTHORIZATION:%{HTTP:Authorization}]
 # The following rule tells Apache that if the requested filename
 # exists, simply serve it.
-RewriteCond %{REQUEST_FILENAME} -s [OR]
+RewriteCond %{REQUEST_FILENAME} -f [OR]
 RewriteCond %{REQUEST_FILENAME} -l [OR]
 RewriteCond %{REQUEST_FILENAME} -d
 RewriteRule ^.*$ - [NC,L]


### PR DESCRIPTION
Breaks serving 0-byte files where only the file name is significant, such as those used in HTTP challenges for domain verification, SSL cert issuance, etc.

|    Q          |   A
|---------------|----
| Documentation | no
| Bugfix        | yes
| BC Break      | no
| New Feature   | no
| RFC           | no
| QA            | no

### Description

This was a fix to a downstream issue (https://github.com/shlinkio/shlink/issues/988) due to which Let's Encrypt SSL certificates failed to issue/renew on Litespeed Web Server (an Apache-compatible server).