### PR TITLE
Optimise RewriteRules/Conds

### DIFF
--- a/public/.htaccess
+++ b/public/.htaccess
@@ -1,12 +1,12 @@
 RewriteEngine On
 # The following rule allows authentication to work with fast-cgi
-RewriteRule .* - [E=HTTP_AUTHORIZATION:%{HTTP:Authorization}]
+RewriteRule ^ - [E=HTTP_AUTHORIZATION:%{HTTP:Authorization}]
 # The following rule tells Apache that if the requested filename
 # exists, simply serve it.
 RewriteCond %{REQUEST_FILENAME} -s [OR]
 RewriteCond %{REQUEST_FILENAME} -l [OR]
 RewriteCond %{REQUEST_FILENAME} -d
-RewriteRule ^.*$ - [NC,L]
+RewriteRule ^ - [NC,L]
 
 # The following rewrites all other queries to index.php. The
 # condition ensures that if you are using Apache aliases to do
@@ -14,6 +14,6 @@ RewriteRule ^.*$ - [NC,L]
 # allow proper resolution of the index.php file; it will work
 # in non-aliased environments as well, providing a safe, one-size
 # fits all solution.
-RewriteCond %{REQUEST_URI}::$1 ^(/.+)(.+)::\2$
-RewriteRule ^(.*) - [E=BASE:%1]
-RewriteRule ^(.*)$ %{ENV:BASE}index.php [NC,L]
+RewriteCond $0::%{REQUEST_URI} ^([^:]*+(?::[^:]*+)*?)::(/.+?)\1$
+RewriteRule .+ - [E=BASE:%2]
+RewriteRule .* %{ENV:BASE}index.php [NC,L]


### PR DESCRIPTION
The base URL determination is substantially faster if the input starts with the expected common substring (the initial match of the RewriteRule), rather than repeatedly recalculating the backreferences until the lengths match.

A demonstration that the updated version can take take two orders of magnitude fewer steps:
original: https://regex101.com/r/Lvi7Pu/1
updated: https://regex101.com/r/RXjdVZ/1

Also simplify previous rules where the match itself is not used in a condition or rewrite.

|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | ?
| BC Break      | no
| New Feature   | no
| RFC           | ?
| QA            | no

### Description

Regexps are a performance drain when unoptimised, especially when they rely of heavy backtracking and re-checking for matches. PCRE has built-in features to optimise for un/greedy matching which The BASE env var determination was not using. This patch optimises both the logic and the operators to perform much faster matching.

My only concern is that it appears as though the original did not always rewrite to the `index.php` file, but surely that can't be true: https://regex101.com/r/Lvi7Pu/2

I could modifiy this so that the rewritten path has only a relative prefix (except retain the `/` in the env var for backwards compat.), which makes more sense to me because rules are already matched against relative paths in `.htaccess` context.