### PR TITLE
Update Twig documentation URI

### DIFF
--- a/src/App/src/Handler/HomePageHandler.php
+++ b/src/App/src/Handler/HomePageHandler.php
@@ -61,7 +61,7 @@ class HomePageHandler implements RequestHandlerInterface
             case 'Elie\PHPDI\Config\ContainerWrapper':
             case PHPDIContainer::class:
                 $data['containerName'] = 'PHP-DI';
-                $data['containerDocs'] = 'http://php-di.org';
+                $data['containerDocs'] = 'https://php-di.org';
                 break;
             case MinimalContainer::class:
                 $data['containerName'] = 'Chubbyphp Container';
@@ -86,7 +86,7 @@ class HomePageHandler implements RequestHandlerInterface
 
         if ($this->template instanceof PlatesRenderer) {
             $data['templateName'] = 'Plates';
-            $data['templateDocs'] = 'http://platesphp.com/';
+            $data['templateDocs'] = 'https://platesphp.com/';
         } elseif ($this->template instanceof TwigRenderer) {
             $data['templateName'] = 'Twig';
             $data['templateDocs'] = 'https://twig.symfony.com';

--- a/src/App/src/Handler/HomePageHandler.php
+++ b/src/App/src/Handler/HomePageHandler.php
@@ -89,7 +89,7 @@ class HomePageHandler implements RequestHandlerInterface
             $data['templateDocs'] = 'http://platesphp.com/';
         } elseif ($this->template instanceof TwigRenderer) {
             $data['templateName'] = 'Twig';
-            $data['templateDocs'] = 'http://twig.sensiolabs.org/documentation';
+            $data['templateDocs'] = 'https://twig.symfony.com';
         } elseif ($this->template instanceof LaminasViewRenderer) {
             $data['templateName'] = 'Laminas View';
             $data['templateDocs'] = 'https://docs.laminas.dev/laminas-view/';

--- a/test/MezzioInstallerTest/HomePageResponseTest.php
+++ b/test/MezzioInstallerTest/HomePageResponseTest.php
@@ -112,7 +112,7 @@ class HomePageResponseTest extends OptionalPackagesTestCase
         ],
         PhpDIContainer::class                 => [
             'containerName' => 'PHP-DI',
-            'containerDocs' => 'http://php-di.org',
+            'containerDocs' => 'https://php-di.org',
         ],
         ChubbyphpContainer::class             => [
             'containerName' => 'Chubbyphp Container',


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | yes
| BC Break      | no
| New Feature   | no
| RFC           | no
| QA            | no

### Description

The Twig documentation URI on the default home page was pointing to the
old site.