### PR TITLE
Disable process timeout for composer serve

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,39 +49,10 @@ After choosing and installing the packages you want, go to the
 `<project-path>` and start PHP's built-in web server to verify installation:
 
 ```bash
-$ composer run --timeout=0 serve
+$ composer serve
 ```
 
 You can then browse to http://localhost:8080.
-
-> ### Linux users
->
-> On PHP versions prior to 7.1.14 and 7.2.2, this command might not work as
-> expected due to a bug in PHP that only affects linux environments. In such
-> scenarios, you will need to start the [built-in web
-> server](http://php.net/manual/en/features.commandline.webserver.php) yourself,
-> using the following command:
->
-> ```bash
-> $ php -S 0.0.0.0:8080 -t public/ public/index.php
-> ```
-
-> ### Setting a timeout
->
-> Composer commands time out after 300 seconds (5 minutes). On Linux-based
-> systems, the `php -S` command that `composer serve` spawns continues running
-> as a background process, but on other systems halts when the timeout occurs.
->
-> As such, we recommend running the `serve` script using a timeout. This can
-> be done by using `composer run` to execute the `serve` script, with a
-> `--timeout` option. When set to `0`, as in the previous example, no timeout
-> will be used, and it will run until you cancel the process (usually via
-> `Ctrl-C`). Alternately, you can specify a finite timeout; as an example,
-> the following will extend the timeout to a full day:
->
-> ```bash
-> $ composer run --timeout=86400 serve
-> ```
 
 ## Installing alternative packages
 

--- a/composer.json
+++ b/composer.json
@@ -108,7 +108,10 @@
             "@enable-codestandard",
             "phpcbf"
         ],
-        "serve": "php -S 0.0.0.0:8080 -t public/",
+        "serve": [
+          "Composer\\Config::disableProcessTimeout",
+          "php -S 0.0.0.0:8080 -t public/"
+        ],
         "test": "phpunit --colors=always",
         "test-coverage": "phpunit --colors=always --coverage-clover clover.xml"
     }


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | no
| BC Break      | no
| New Feature   | no
| RFC           | no
| QA            | no

### Description

Composer default timeout is 300s which is not suitable for PHP builtin development server run by `composer serve`.

Composer provides convenience helper to disable timeout for specific scripts since 1.9.0
See https://getcomposer.org/doc/articles/scripts.md#writing-custom-commands
