### PR TITLE
Fix dependency ranges supported by `elie29/zend-phpdi-config` in the installer configuration

### DIFF
--- a/src/MezzioInstaller/config.php
+++ b/src/MezzioInstaller/config.php
@@ -9,7 +9,7 @@ return [
             'version' => '^1.0',
         ],
         'elie29/zend-phpdi-config'           => [
-            'version' => '^6.0',
+            'version' => '^6.0 || ^8.0 || ^9.0',
         ],
         'filp/whoops'                        => [
             'version' => '^2.7.1',


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | yes
| BC Break      | no
| New Feature   | no
| RFC           | no
| QA            | no

### Description

Take into account all supported PHP versions with elie29/zend-phpdi-config

Fixes #71 
