### PR TITLE
Remove unintentionally undelivered `phpunit.xml.dist` from `export-ignore`

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -2,7 +2,6 @@
 /.github/ export-ignore
 /.laminas-ci.json export-ignore
 /phpcs.xml.dist export-ignore
-/phpunit.xml.dist export-ignore
 /psalm.xml.dist export-ignore
 /psalm-baseline.xml export-ignore
 /renovate.json export-ignore


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | yes
| BC Break      | no
| New Feature   | no
| RFC           | no
| QA            | no

### Description

closes https://github.com/mezzio/mezzio-skeleton/issues/109 It was unintentionally missing from the distribution files at https://github.com/mezzio/mezzio-skeleton/pull/97.

I have checked that the following script does not generate any errors.

```sh
git clean -f .
git restore .
rm -r .gitattributes .github .laminas-ci.json phpcs.xml.dist phpunit.xml.dist psalm.xml.dist psalm-baseline.xml renovate.json

yes 1 | composer install
```


Fixes #109