### PR TITLE
Add `composer create-project` test to GitHub Actions

### DIFF
--- a/.github/workflows/create-project.yml
+++ b/.github/workflows/create-project.yml
@@ -1,0 +1,36 @@
+name: "Create Project"
+
+on:
+  pull_request:
+  push:
+    branches:
+      - '[0-9]+.[0-9]+.x'
+      - 'refs/pull/*'
+    tags:
+
+jobs:
+  build:
+    strategy:
+      matrix:
+        php_version:
+          - '@latest'
+          - '@lowest'
+    runs-on: ubuntu-latest
+    timeout-minutes: 3
+    steps:
+      - name: Checkout CI environment
+        uses: laminas/laminas-continuous-integration-action@v1
+        with:
+          php: ${{ matrix.php_version }}
+      - name: Checkout sourcecode
+        uses: actions/checkout@v3
+      - name: Test create-project
+        run: |
+          cd ..
+          yes 1 | composer create-project mezzio/mezzio-skeleton test-new-project \
+              --repository='{"type": "path", "url": "./mezzio-skeleton"}' --stability=dev
+          ls -la test-new-project
+          cd test-new-project
+          test -f config/container.php
+          test -f config/routes.php
+          echo "Successfully created project"


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | no
| BC Break      | no
| New Feature   | no
| RFC           | no
| QA            | yes

### Description

refs https://github.com/mezzio/mezzio-skeleton/pull/114#issuecomment-1373870134

Add a GitHub Action that reproduces the behavior of `composer create-project`.

<!--
Tell us about why this change is necessary:
- Are you fixing a bug or providing a failing unit test to demonstrate a bug?
  - How do you reproduce it?
  - What did you expect to happen?
  - What actually happened?
  - TARGET THE master BRANCH

- Are you adding documentation?
  - TARGET THE master BRANCH

- Are you providing a QA improvement (additional tests, CS fixes, etc.) that
  does not change behavior?
  - Explain why the changes are necessary
  - TARGET THE master BRANCH

- Are you fixing a BC Break?
  - How do you reproduce it?
  - What was the previous behavior?
  - What is the current behavior?
  - TARGET THE master BRANCH

- Are you adding something the library currently does not support?
  - Why should it be added?
  - What will it enable?
  - How will the code be used?
  - TARGET THE develop BRANCH

- Are you refactoring code?
  - Why do you feel the refactor is necessary?
  - What types of refactoring are you doing?
  - TARGET THE develop BRANCH
-->
