### PR TITLE
Add composer post install/update hooks to clear config cache

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -93,6 +93,8 @@
         "post-create-project-cmd": [
             "@development-enable"
         ],
+        "post-install-cmd": "@clear-config-cache",
+        "post-update-cmd": "@clear-config-cache",
         "development-disable": "laminas-development-mode disable",
         "development-enable": "laminas-development-mode enable",
         "development-status": "laminas-development-mode status",
@@ -117,5 +119,8 @@
         ],
         "test": "phpunit --colors=always",
         "test-coverage": "phpunit --colors=always --coverage-clover clover.xml"
+    },
+    "scripts-descriptions": {
+        "clear-config-cache": "Clears merged config cache. Required for config changes to be applied."
     }
 }


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | no
| BC Break      | no
| New Feature   | yes
| RFC           | no
| QA            | no

### Description

Users occasionally seek help with container services not found or config not working. One of the reasons that occurs is because they have stale config cache.

This change will make any composer install or update clear potentially stale config cache, preventing such issue.