### PR TITLE
Switch development config to use ConfigAggregator

### DIFF
--- a/config/autoload/development.local.php.dist
+++ b/config/autoload/development.local.php.dist
@@ -8,6 +8,8 @@
  *
  * Developers on your team will then automatically enable them by calling on
  * `composer development-enable`.
+ *
+ * You may also create files matching the glob pattern `{,*.}{global,local}-development.php`.
  */
 
 declare(strict_types=1);

--- a/config/autoload/global.dev.php.dist
+++ b/config/autoload/global.dev.php.dist
@@ -9,7 +9,7 @@
  * Developers on your team will then automatically enable them by calling on
  * `composer development-enable`.
  *
- * You may also create files matching the glob pattern `{,*.}{global,local}-development.php`.
+ * You may also create files matching the glob pattern `{,*.}{global,local}.dev.php`.
  */
 
 declare(strict_types=1);

--- a/config/development.config.php.dist
+++ b/config/development.config.php.dist
@@ -13,7 +13,7 @@
  * DO NOT MODIFY THIS FILE.
  *
  * Provide your own development-mode settings by editing the file
- * `config/autoload/development.local.php.dist`.
+ * `config/autoload/global.dev.php.dist`.
  *
  * Because this file is aggregated last, it ensures:
  *
@@ -30,7 +30,7 @@ use Laminas\ConfigAggregator\ConfigAggregator;
 use Laminas\ConfigAggregator\PhpFileProvider;
 
 $aggregator = new ConfigAggregator([
-    new PhpFileProvider(realpath(__DIR__) . '/autoload/{,*.}{global,local}-development.php'),
+    new PhpFileProvider(realpath(__DIR__) . '/autoload/{,*.}{global,local}.dev.php'),
     new ArrayProvider([
         'debug'                        => true,
         ConfigAggregator::ENABLE_CACHE => false,

--- a/config/development.config.php.dist
+++ b/config/development.config.php.dist
@@ -15,8 +15,10 @@
  * Provide your own development-mode settings by editing the file
  * `config/autoload/development.local.php.dist`.
  *
- * Because this file is aggregated last, it simply ensures:
+ * Because this file is aggregated last, it ensures:
  *
+ * - ConfigProviders for `--dev` dependencies are loaded when in development mode
+ * - Development-only overrides are applied
  * - The `debug` flag is _enabled_.
  * - Configuration caching is _disabled_.
  */
@@ -24,8 +26,16 @@
 declare(strict_types=1);
 
 use Laminas\ConfigAggregator\ConfigAggregator;
+use Laminas\ConfigAggregator\PhpFileProvider;
 
-return [
-    'debug'                        => true,
-    ConfigAggregator::ENABLE_CACHE => false,
-];
+$aggregator = new ConfigAggregator([
+    new PhpFileProvider(realpath(__DIR__) . '/autoload/{,*.}{global,local}-development.php'),
+    function() {
+        return [
+            'debug'                        => true,
+            ConfigAggregator::ENABLE_CACHE => false,
+        ];
+    },
+]);
+
+return $aggregator->getMergedConfig();

--- a/config/development.config.php.dist
+++ b/config/development.config.php.dist
@@ -25,17 +25,16 @@
 
 declare(strict_types=1);
 
+use Laminas\ConfigAggregator\ArrayProvider;
 use Laminas\ConfigAggregator\ConfigAggregator;
 use Laminas\ConfigAggregator\PhpFileProvider;
 
 $aggregator = new ConfigAggregator([
     new PhpFileProvider(realpath(__DIR__) . '/autoload/{,*.}{global,local}-development.php'),
-    function() {
-        return [
-            'debug'                        => true,
-            ConfigAggregator::ENABLE_CACHE => false,
-        ];
-    },
+    new ArrayProvider([
+        'debug'                        => true,
+        ConfigAggregator::ENABLE_CACHE => false,
+    ]),
 ]);
 
 return $aggregator->getMergedConfig();

--- a/src/MezzioInstaller/config.php
+++ b/src/MezzioInstaller/config.php
@@ -258,13 +258,13 @@ return [
                         'filp/whoops',
                     ],
                     'flat'     => [
-                        'Resources/config/error-handler-whoops.php' => 'config/autoload/development.local.php.dist',
+                        'Resources/config/error-handler-whoops.php' => 'config/autoload/global.dev.php.dist',
                     ],
                     'modular'  => [
-                        'Resources/config/error-handler-whoops.php' => 'config/autoload/development.local.php.dist',
+                        'Resources/config/error-handler-whoops.php' => 'config/autoload/global.dev.php.dist',
                     ],
                     'minimal'  => [
-                        'Resources/config/error-handler-whoops.php' => 'config/autoload/development.local.php.dist',
+                        'Resources/config/error-handler-whoops.php' => 'config/autoload/global.dev.php.dist',
                     ],
                 ],
             ],

--- a/test/MezzioInstallerTest/ProjectSandboxTrait.php
+++ b/test/MezzioInstallerTest/ProjectSandboxTrait.php
@@ -120,7 +120,7 @@ trait ProjectSandboxTrait
         Assert::assertFileExists($target);
 
         $target = sprintf(
-            '%s%sconfig%sautoload%sdevelopment.local.php',
+            '%s%sconfig%sautoload%sglobal.dev.php',
             $this->projectRoot,
             DIRECTORY_SEPARATOR,
             DIRECTORY_SEPARATOR,


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | no
| BC Break      | no
| New Feature   | yes
| RFC           | no
| QA            | no

### Description

This PR changes `development.config.php.dist` to use a `ConfigAggregator` so https://github.com/laminas/laminas-component-installer/pull/68 can inject `--dev`-only config providers. It also adds the ability to load dev-only configuration from `{,*.}{global,local}-development.php` files - like MVC does - so settings in the development config providers can be overridden.

I'm not sure what I can do to test these changes. As far as I can tell the existing tests don't cover the structure of the config files, but if anyone's got any pointers...
