### PR TITLE
Exclude composer.lock from exported archive to avoid lockfile induced installation failure.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,6 +1,7 @@
 /.gitattributes export-ignore
 /.github/ export-ignore
 /.laminas-ci.json export-ignore
+/composer.lock export-ignore
 /phpcs.xml.dist export-ignore
 /psalm.xml.dist export-ignore
 /psalm-baseline.xml export-ignore


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | yes/no
| BC Break      | no
| New Feature   | yes
| RFC           | no
| QA            | no

### Description

Composer lockfile is preventing successful installation after composer create-project. This attempts to remove lockfile, however installer is invoked from pre-install hook and it potentially can be too late to remove lockfile.